### PR TITLE
update HTMLHint to 0.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "htmlhint": "0.9.8"
+    "htmlhint": "~0.9.8"
   }
 }


### PR DESCRIPTION
This change allows automatically (when you install a plugin dependency) install all new patch releases main package (HTMLHint).