### PR TITLE
Upgrade to future

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,7 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+# For package.json
+[*.json]
+indent_size = 2

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,14 +1,18 @@
 {
   "curly": true,
-  "eqeqeq": true,
-  "immed": true,
-  "latedef": true,
-  "newcap": true,
-  "noarg": true,
-  "sub": true,
+  "expr": true,
+  "newcap": false,
+  "regexdash": true,
+  "trailing": true,
   "undef": true,
-  "boss": true,
+  "unused": true,
+  "maxerr": 100,
+
   "eqnull": true,
+  "evil": true,
+  "sub": true,
+
   "node": true,
-  "es5": true
+  "-W099": true,
+  "-W100": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 sudo: false
-
 language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - "4.1"
-    
-cache:
-  directories:
-    - node_modules
+    - "4"
+    - "stable"
 
-matrix:
-  fast_finish: true
-  
-script: "grunt"
+before_script:
+    - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,25 @@ module.exports = function(grunt) {
                 },
                 src: 'test/fixtures/*.html'
             }
+        },
+
+        shell: {
+            htmlhint: {
+                command: 'grunt htmlhint',
+                options: {
+                    callback: function (_, stdout, stderr, cb) {
+                        if (/invalid\.html/.test(stdout)) {
+                            if (/\(doctype-first\)/.test(stdout) && /\(tag-pair\)/.test(stdout)) {
+                                cb();
+                            } else {
+                                cb(false);
+                            }
+                        } else {
+                            cb(false);
+                        }
+                    }
+                }
+            }
         }
 
     });
@@ -40,8 +59,9 @@ module.exports = function(grunt) {
 
     // These plugins provide necessary tasks.
     grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-shell');
 
     // By default, lint and run all tests.
-    grunt.registerTask('default', ['jshint', 'htmlhint']);
+    grunt.registerTask('default', ['jshint', 'shell:htmlhint']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,38 +10,38 @@
 
 module.exports = function(grunt) {
 
-  // Project configuration.
-  grunt.initConfig({
-    jshint: {
-      all: [
-        'Gruntfile.js',
-        'tasks/*.js'
-      ],
-      options: {
-        jshintrc: '.jshintrc',
-      },
-    },
-
-    // Configuration to be run (and then tested).
-    htmlhint: {
-      all: {
-        options: {
-          'tag-pair': true,
-          'htmlhintrc': 'test/.htmlhintrc'
+    // Project configuration.
+    grunt.initConfig({
+        jshint: {
+            all: [
+                'Gruntfile.js',
+                'tasks/*.js'
+            ],
+            options: {
+                jshintrc: '.jshintrc'
+            }
         },
-        src: 'test/fixtures/*.html'
-      }
-    }
 
-  });
+        // Configuration to be run (and then tested).
+        htmlhint: {
+            all: {
+                options: {
+                    'tag-pair': true,
+                    'htmlhintrc': 'test/.htmlhintrc'
+                },
+                src: 'test/fixtures/*.html'
+            }
+        }
 
-  // Actually load this plugin's task(s).
-  grunt.loadTasks('tasks');
+    });
 
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-jshint');
+    // Actually load this plugin's task(s).
+    grunt.loadTasks('tasks');
 
-  // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'htmlhint']);
+    // These plugins provide necessary tasks.
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+
+    // By default, lint and run all tests.
+    grunt.registerTask('default', ['jshint', 'htmlhint']);
 
 };

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-htmlhint
 
-> Lint html files with htmlhint.
+> Lint html files with [HTMLHint](https://github.com/yaniswang/HTMLHint).
 
 [![Build Status](https://travis-ci.org/yaniswang/grunt-htmlhint.svg)](https://travis-ci.org/yaniswang/grunt-htmlhint)
 [![NPM version](https://img.shields.io/npm/v/grunt-htmlhint.svg?style=flat)](https://www.npmjs.com/package/grunt-htmlhint)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "grunt-htmlhint",
   "description": "Validate html files with htmlhint.",
   "version": "0.9.12-fix",
-  "homepage": "https://github.com/yaniswang/grunt-htmlhint",
+  "licenses": "MIT",
+  "keywords": [
+    "gruntplugin",
+    "htmlhint",
+    "html",
+    "hint"
+  ],
   "author": {
     "name": "Yanis Wang",
     "email": "yanis.wang@gmail.com",
@@ -12,21 +18,11 @@
     "type": "git",
     "url": "git@github.com:yaniswang/grunt-htmlhint.git"
   },
-  "bugs": {
-    "url": "https://github.com/yaniswang/grunt-htmlhint/issues"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/yaniswang/grunt-htmlhint/blob/master/LICENSE-MIT"
-    }
-  ],
-  "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "grunt --force"
+    "test": "grunt"
   },
   "files": [
     "tasks"
@@ -35,9 +31,6 @@
     "grunt-contrib-jshint": "~0.11.3",
     "grunt": "~0.4.5"
   },
-  "keywords": [
-    "gruntplugin"
-  ],
   "dependencies": {
     "htmlhint": "~0.9.12"
   }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,8 @@
     "tasks"
   ],
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt": "~0.4.1",
-    "grunt-cli": "0.1.6"
-  },
-  "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt-contrib-jshint": "~0.11.3",
+    "grunt": "~0.4.5"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "scripts": {
     "test": "grunt --force"
   },
+  "files": [
+    "tasks"
+  ],
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",
     "grunt": "~0.4.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "tasks"
   ],
   "devDependencies": {
+    "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.11.3",
-    "grunt": "~0.4.5"
+    "grunt-shell": "^1.1.2"
   },
   "dependencies": {
     "htmlhint": "~0.9.12"

--- a/tasks/htmlhint.js
+++ b/tasks/htmlhint.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
 
     grunt.registerMultiTask('htmlhint', 'Validate html files with htmlhint.', function() {
 
-        var HTMLHint = require("htmlhint").HTMLHint;
+        var HTMLHint = require('htmlhint').HTMLHint;
         var options = this.options({
                 force: false
             }),
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
         var fileCount = 0;
         arrFilesSrc.forEach(function(filepath) {
             var file = grunt.file.read(filepath),
-                msg = "   " + filepath,
+                msg = '   ' + filepath,
                 messages;
             if (file.length) {
                 messages = HTMLHint.verify(file, options);

--- a/tasks/htmlhint.js
+++ b/tasks/htmlhint.js
@@ -64,8 +64,4 @@ module.exports = function(grunt) {
 
     });
 
-
-    function repeatStr(n, str){
-        return new Array(n + 1).join(str || ' ');
-    }
 };


### PR DESCRIPTION
Changelog:

  * Use 2 spaces for JSON files in editorconfig
  * **Ignoring files for testing**. Excludes unnecessary files from redist package. The average user does
not need tests in the package. They need developers.
  * Update dependencies
  * Update packge.json to the current standard + added keywords
  * Update Travis CI configuration
  * Update JSHint rules form the HTMLHint package
  * Pretty code (single quotes, use 4 spaces in all JS files
  * Update tests to their passing using the grunt-shell

![image](https://cloud.githubusercontent.com/assets/7034281/10894287/b47abe36-81be-11e5-93b6-17570831d163.png)